### PR TITLE
allow multiple submissions of pitscouting through sessions

### DIFF
--- a/src/lib/components/pit-scouting/Group.svelte
+++ b/src/lib/components/pit-scouting/Group.svelte
@@ -9,9 +9,10 @@
 		team: number;
 		questions: Scouting.PIT.QuestionData[];
 		answers: DataArr<typeof Scouting.PIT.Answers.data.structure>;
+		session: string;
 	}
 
-	const { group, team, questions, answers }: Props = $props();
+	const { group, team, questions, answers, session }: Props = $props();
 
 	let questionIds: string[] = $state([]);
 
@@ -31,7 +32,7 @@
 			{#if i > 0}
 				<hr />
 			{/if}
-			<Question {question} {team} {answers} />
+			<Question {question} {team} {answers} {session} />
 		{/each}
 	</div>
 </div>

--- a/src/lib/components/pit-scouting/Question.svelte
+++ b/src/lib/components/pit-scouting/Question.svelte
@@ -10,9 +10,10 @@
 		question: Scouting.PIT.QuestionData;
 		team: number;
 		answers: DataArr<typeof Scouting.PIT.Answers.data.structure>;
+		session: string;
 	}
 
-	const { question, team, answers }: Props = $props();
+	const { question, team, answers, session }: Props = $props();
 
 	let answer: Scouting.PIT.AnswerData | undefined = $state(
 		answers.data.find((a) => a.data.questionId === question.data.id && a.data.team === team)
@@ -73,7 +74,8 @@
 				questionId: question.data.id,
 				answer: JSON.stringify($value),
 				team,
-				accountId // Ideally, this would be done on the backend but it's okay to be a little insecure
+				accountId, // Ideally, this would be done on the backend but it's okay to be a little insecure
+				session,
 			});
 			// retrieveAnswer();
 		}

--- a/src/lib/components/pit-scouting/Section.svelte
+++ b/src/lib/components/pit-scouting/Section.svelte
@@ -10,9 +10,10 @@
 		groups: Scouting.PIT.GroupData[];
 		questions: DataArr<typeof Scouting.PIT.Questions.data.structure>;
 		answers: DataArr<typeof Scouting.PIT.Answers.data.structure>;
+		session: string;
 	}
 
-	const { section, team, groups, questions, answers }: Props = $props();
+	const { section, team, groups, questions, answers, session }: Props = $props();
 
 	$effect(() => {
 		if (!section || !team) return; // trigger on section or team change
@@ -31,6 +32,7 @@
 				{team}
 				questions={$questions.filter((q) => q.data.groupId === group.data.id)}
 				{answers}
+				{session}
 			/>
 		</div>
 	{/each}

--- a/src/lib/model/scouting.ts
+++ b/src/lib/model/scouting.ts
@@ -269,7 +269,8 @@ export namespace Scouting {
 			structure: {
 				name: 'string',
 				order: 'number',
-				eventKey: 'string'
+				eventKey: 'string',
+				allowMultiple: 'boolean',
 			},
 			socket: sse,
 			browser
@@ -316,7 +317,8 @@ export namespace Scouting {
 				questionId: 'string',
 				answer: 'string',
 				team: 'number',
-				accountId: 'string'
+				accountId: 'string',
+				session: 'string',
 			},
 			socket: sse,
 			browser
@@ -324,6 +326,17 @@ export namespace Scouting {
 
 		export type AnswerData = StructData<typeof Answers.data.structure>;
 		export type AnswerArr = DataArr<typeof Answers.data.structure>;
+
+		export const AnswerSessions = new Struct({
+			name: 'pit_answer_sessions',
+			structure: {
+				section: 'string',
+				createdBy: 'string',
+				answers: 'number',
+			},
+			socket: sse,
+			browser,
+		});
 
 		export type Options = {};
 
@@ -360,7 +373,8 @@ export namespace Scouting {
 			question: QuestionData,
 			answer: string[],
 			team: number,
-			account: Account.AccountData
+			account: Account.AccountData,
+			session: string,
 		) => {
 			return attemptAsync(async () => {
 				if (!question.data.id) throw new Error('Question ID not found');
@@ -371,7 +385,8 @@ export namespace Scouting {
 						questionId: question.data.id,
 						answer: JSON.stringify(answer),
 						team,
-						accountId
+						accountId,
+						session
 					})
 				).unwrap();
 

--- a/src/routes/dashboard/event/[eventKey]/edit-pit-scouting/+page.svelte
+++ b/src/routes/dashboard/event/[eventKey]/edit-pit-scouting/+page.svelte
@@ -27,7 +27,8 @@
 		const res = await Scouting.PIT.Sections.new({
 			name,
 			order: $sections.length,
-			eventKey
+			eventKey,
+			allowMultiple: await confirm('Do you want to allow multiple submissions?'),
 		});
 	};
 

--- a/src/routes/dashboard/event/[eventKey]/pit-scouting/+page.svelte
+++ b/src/routes/dashboard/event/[eventKey]/pit-scouting/+page.svelte
@@ -29,7 +29,7 @@
 			{#each $sections as section, i}
 				<div class="col-md-4 p-3">
 					<a
-						href="/dashboard/event/{eventKey}/pit-scouting/{i}"
+						href="/dashboard/event/{eventKey}/pit-scouting/{section.data.id}"
 						class="text-reset text-decoration-none"
 					>
 						<!-- <a href="{location.href}/pitscouting/{i}">  -->

--- a/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.server.ts
+++ b/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.server.ts
@@ -1,0 +1,56 @@
+import { FIRST } from '$lib/server/structs/FIRST.js';
+import { Scouting } from '$lib/server/structs/scouting.js';
+import { Event } from '$lib/server/utils/tba.js';
+import { fail, redirect } from '@sveltejs/kit';
+import { ServerCode } from 'ts-utils/status';
+
+export const load = async (event) => {
+    if (!event.locals.account) throw redirect(ServerCode.temporaryRedirect, '/account/sign-in');
+    const { eventKey, section } = event.params;
+
+    const sections = (
+        await Scouting.PIT.Sections.fromProperty('eventKey', eventKey, {
+            type: 'stream'
+        }).await()
+    )
+        .unwrap()
+        .sort((a, b) => a.data.order - b.data.order);
+
+    const s = sections.find(s => s.id === event.params.section)
+
+    if (!s) throw fail(404);
+
+    const e = (await Event.getEvent(eventKey)).unwrap();
+    const teams = (await e.getTeams()).unwrap();
+    const team = teams.find((t) => t.tba.team_number === parseInt(event.params.team));
+    if (!team) throw fail(404);
+
+    const info = (
+        await Scouting.PIT.getScoutingInfoFromSection(
+            parseInt(event.params.team),
+            s,
+            event.params.sessionId
+        )
+    ).unwrap();
+
+    const pictures = (
+        await FIRST.getTeamPictures(parseInt(event.params.team), event.params.eventKey)
+    ).unwrap();
+    return {
+        section: s.safe(),
+        eventKey,
+        sections: sections.map((s) => s.safe()),
+        teams: teams.map((t) => t.tba),
+        team: team.tba,
+        sectionIndex: parseInt(section),
+        event: e.tba,
+        questions: info.questions.map((q) => q.safe()),
+        answers: info.answers.map((a) => ({
+            answer: a.answer.safe(),
+            account: a.account?.safe()
+        })),
+        groups: info.groups.map((g) => g.safe()),
+        pictures: pictures.map((p) => p.safe()),
+        session: event.params.sessionId,
+    };
+};

--- a/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.svelte
+++ b/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import nav from '$lib/imports/robot-display.js';
+	import Section from '$lib/components/pit-scouting/Section.svelte';
+	import { afterNavigate, goto } from '$app/navigation';
+	import { sleep } from 'ts-utils/sleep';
+	import { onMount } from 'svelte';
+	import { listen } from '$lib/utils/struct-listener.js';
+	import PictureDisplay from '$lib/components/robot-display/PictureDisplay.svelte';
+	import { TBAEvent, TBATeam } from '$lib/utils/tba.js';
+
+	const { data = $bindable() } = $props();
+	// const { eventKey, section, sections, teams, team, sectionIndex } = data;
+	const eventKey = $derived(data.eventKey);
+	const section = $derived(data.section);
+	const sections = $derived(data.sections);
+	const teams = $derived(data.teams);
+	const event = $derived(new TBAEvent(data.event));
+	const team = $derived(new TBATeam(data.team, event));
+	const sectionIndex = $derived(data.sectionIndex);
+	const groups = $derived(data.groups);
+	const answers = $derived(data.answers);
+	const questions = $derived(data.questions);
+	const pictures = $derived(data.pictures);
+
+	$effect(() => nav(event.tba));
+
+	let scroller: HTMLDivElement;
+
+	afterNavigate(() => {
+		const btn = scroller.querySelector(`[data-team="${team.tba.team_number}"]`);
+		if (btn) {
+			sleep(500).then(() =>
+				btn.scrollIntoView({
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'center'
+				})
+			);
+		}
+	});
+
+	onMount(() => {
+		const offSections = listen(sections, (s) => s.data.eventKey === event.tba.key);
+		const offGroups = listen(groups, (g) => section.data.id === g.data.sectionId);
+		const offQuestions = listen(
+			questions,
+			(q) => !!groups.data.find((g) => g.data.id === q.data.groupId)
+		);
+		const offAnswers = listen(
+			answers,
+			(a) => !!questions.data.find((q) => q.data.id === a.data.questionId)
+		);
+
+		return () => {
+			offSections();
+			offGroups();
+			offQuestions();
+			offAnswers();
+		};
+	});
+</script>
+
+<div class="container">
+	<div class="row mb-3">
+		<h2>Pitscouting: {team.tba.nickname}</h2>
+	</div>
+	<div class="row mb-3">
+		<div class="ws-nowrap p-3 mb-3" bind:this={scroller} style="overflow-x: auto;">
+			{#each teams as t}
+				<a
+					type="button"
+					href="/dashboard/event/{eventKey}/pit-scouting/{sectionIndex}/team/{t.team_number}"
+					class="btn mx-2"
+					class:btn-primary={t.team_number !== team.tba.team_number}
+					class:btn-outline-secondary={t.team_number === team.tba.team_number}
+					class:btn-disabled={t.team_number === team.tba.team_number}
+					class:text-muted={t.team_number === team.tba.team_number}
+					onclick={(e) => {
+						if (t.team_number === team.tba.team_number) {
+							return e.preventDefault();
+						}
+					}}
+					data-team={t.team_number}
+				>
+					{t.team_number}
+				</a>
+			{/each}
+		</div>
+	</div>
+	<div class="row mb-3">
+		<div class="no-scroll-y ws-nowrap" style="overflow-x: auto;">
+			{#each $sections as section, i}
+				<button
+					onclick={() => {
+						goto(`/dashboard/event/${eventKey}/pit-scouting/${section.data.id}/team/${team.tba.team_number}`);
+					}}
+					class="btn btn-primary mx-2"
+					disabled={sectionIndex === i}
+				>
+					{section.data.name}
+				</button>
+			{/each}
+		</div>
+	</div>
+	{#key team}
+		<Section
+			{section}
+			team={team.tba.team_number}
+			groups={$groups.filter((g) => g.data.sectionId === section.data.id)}
+			{questions}
+			{answers}
+            session={data.session}
+		/>
+		<div style="height: 300px" class="layer-1">
+			<PictureDisplay {team} {event} teamPictures={pictures} />
+		</div>
+	{/key}
+</div>

--- a/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.ts
+++ b/src/routes/dashboard/event/[eventKey]/pit-scouting/[section]/team/[team]/[sessionId]/+page.ts
@@ -34,6 +34,7 @@ export const load = (event) => {
 		answeredAccounts: event.data.answers
 			.map((a) => a.account)
 			.filter(Boolean)
-			.map((a) => Account.Account.Generator(a))
+			.map((a) => Account.Account.Generator(a)),
+		session: event.data.session,
 	};
 };


### PR DESCRIPTION
This allows the ability to create multiple submissions of a single pit scouting form. This is done through pit-scouting "sessions" which generate a unique token whenever you want to submit a new form. 